### PR TITLE
Change to fetch variables in runtime instead of compile-time

### DIFF
--- a/lib/repo/schema_type.ex
+++ b/lib/repo/schema_type.ex
@@ -1,13 +1,11 @@
 defmodule ExAudit.Type.Schema do
   @behaviour Ecto.Type
 
-  @schemas Application.get_env(:ex_audit, :tracked_schemas, [])
-
   def cast(schema) when is_atom(schema) do
-    case schema do
-      schema when schema in @schemas -> {:ok, schema}
+    case Enum.member?(schemas(), schema) do
+      true -> {:ok, schema}
       _ -> :error
-    end
+     end
   end
 
   def cast(schema) when is_binary(schema) do
@@ -24,17 +22,21 @@ defmodule ExAudit.Type.Schema do
   end
 
   def dump(schema) do
-    case schema do
-      schema when schema in @schemas -> {:ok, schema.__schema__(:source)}
+    case Enum.member?(schemas(), schema) do
+      true -> {:ok, schema.__schema__(:source)}
       _ -> :error
-    end
+     end
   end
 
   defp get_schema_by_table(table) do
-    Enum.find(@schemas, fn schema ->
+    schemas() |> Enum.find(fn schema ->
       schema.__schema__(:source) == table
     end)
   end
 
   def type, do: :string
+
+  defp schemas do
+    Application.get_env(:ex_audit, :tracked_schemas, [])
+  end
 end

--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -1,7 +1,4 @@
 defmodule ExAudit.Tracking do
-  @version_schema Application.get_env(:ex_audit, :version_schema)
-  @tracked_schemas Application.get_env(:ex_audit, :tracked_schemas)
-
   import Ecto.Query
 
   def find_changes(action, struct_or_changeset, resulting_struct) do
@@ -24,7 +21,7 @@ defmodule ExAudit.Tracking do
   def compare_versions(action, old, new) do
     schema = Map.get(old, :__struct__, Map.get(new, :__struct__))
 
-    if schema in @tracked_schemas do
+    if schema in tracked_schemas() do
       assocs = schema.__schema__(:associations)
 
       patch = ExAudit.Diff.diff(
@@ -73,7 +70,7 @@ defmodule ExAudit.Tracking do
     case changes do
       [] -> :ok
       _ ->
-        Ecto.Repo.Schema.insert_all(module, adapter, @version_schema, changes, opts)
+        Ecto.Repo.Schema.insert_all(module, adapter, version_schema(), changes, opts)
     end
   end
 
@@ -103,5 +100,13 @@ defmodule ExAudit.Tracking do
     deleted_structs = find_assoc_deletion(module, adapter, struct, opts)
 
     insert_versions(module, adapter, deleted_structs, opts)
+  end
+
+  defp tracked_schemas do
+    Application.get_env(:ex_audit, :tracked_schemas)
+  end
+
+  defp version_schema do
+    Application.get_env(:ex_audit, :version_schema)
   end
 end


### PR DESCRIPTION
### Problem

When a config change a full rebuild of the dependency is necessary. It happens because it is reading the configs in compile-time.

### This PR

It is changing to fetch the config values in runtime.