### PR TITLE
remove passing opts to insert_all for version

### DIFF
--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -70,7 +70,8 @@ defmodule ExAudit.Tracking do
         :ok
 
       _ ->
-        module.insert_all(version_schema(), changes)
+        opts = Keyword.drop(opts, [:on_conflict, :conflict_target])
+        module.insert_all(version_schema(), changes, opts)
     end
   end
 

--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -70,7 +70,7 @@ defmodule ExAudit.Tracking do
         :ok
 
       _ ->
-        module.insert_all(version_schema(), changes, opts)
+        module.insert_all(version_schema(), changes)
     end
   end
 


### PR DESCRIPTION
I think we probably dun intend to pass opts to `module.insert_all` inside `Tracking.insert_versions/3`. Because it will actually cause some unexpected exception like in the following example

```elixir
comment_attrs
|> Comment.changeset(
|> Repo.insert(
   on_conflict: :replace_all_except_primary_key,
   conflict_target: [:post_id]
)
```

this options  `[on_conflict: :replace_all_except_primary_key, conflict_target: [:post_id]]` will keep passing down to `module.insert_all(version_schema(), changes, opts)` and create exception.