### PR TITLE
Truncate time to second

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,21 @@
+name: Elixir CI
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: elixir:1.9.1-slim
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+    - name: Run Tests
+      run: mix test

--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -53,7 +53,7 @@ defmodule ExAudit.Tracking do
   end
 
   def insert_versions(module, changes, opts) do
-    now = DateTime.utc_now()
+    now = DateTime.utc_now()|>DateTime.truncate(:second)
 
     custom_fields =
       Keyword.get(opts, :ex_audit_custom, [])


### PR DESCRIPTION
I have this error on upgration ecto 2.2.o to ecto 3.1.1 and it resolve with this commit.

:utc_datetime expects microseconds to be empty, got: #DateTime<2019-10-22 07:56:38.713474Z>

Use `DateTime.truncate(utc_datetime, :second)` (available in Elixir v1.6+) to remove microseconds