### PR TITLE
Automatically run migration for unit tests

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,4 +2,8 @@
 ExAudit.Test.Repo.start_link()
 Ecto.Adapters.SQL.Sandbox.mode(ExAudit.Test.Repo, :auto)
 
+
+migrations_path = Path.join([:code.priv_dir(:ex_audit), "repo", "migrations"])
+Ecto.Migrator.run(ExAudit.Test.Repo, migrations_path, :up, all: true)
+
 ExUnit.start()


### PR DESCRIPTION
Problem: 
- currently migrations have to be executed prior to running tests
- that is not very user-friendly 

Solution: 
- Execute them in test_helper.ex