### PR TITLE
add default return on tracked schemas

### DIFF
--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -112,7 +112,7 @@ defmodule ExAudit.Tracking do
   end
 
   defp tracked_schemas do
-    Application.get_env(:ex_audit, :tracked_schemas)
+    Application.get_env(:ex_audit, :tracked_schemas, [])
   end
 
   defp version_schema do


### PR DESCRIPTION
In some cases when the `Application` environment is not fully filled this library tries to fetch `tracked_schemas` configuration value with no default return. It results in errors on functions that use it expecting a list of schemas.

This default return pattern is already used here on [ExAudit.Type.Schema](https://github.com/ZennerIoT/ex_audit/blob/master/lib/repo/schema_type.ex#L41)