### PR TITLE
Update README to optionally skip the library in test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ defmodule MyApp.Repo do
     otp_app: :my_app,
     adapter: Ecto.Adapters.Postgres
 
-  use ExAudit.Repo
+  # having it in test environment might be unnecessary due to performance overhead
+  if Mix.env() != :test do
+    use ExAudit.Repo
+  end
 end
 ```
 


### PR DESCRIPTION
It's just a reminder for developers that this library comes with performance overhead that they might not want in their test suits.
Is there a better way to temporarily or permanently disable it? 