### PR TITLE
Configurable struct primitives

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -19,4 +19,7 @@ config :ex_audit,
     ExAudit.Test.BlogPost,
     ExAudit.Test.BlogPost.Section,
     ExAudit.Test.Comment
+  ],
+  primitive_structs: [
+    Decimal
   ]

--- a/example/user.ex
+++ b/example/user.ex
@@ -5,18 +5,19 @@ defmodule ExAudit.Test.User do
   @derive {ExAudit.Tracker, except: [:transient_field]}
 
   schema "users" do
-    field :email, :string
-    field :name, :string
+    field(:email, :string)
+    field(:name, :string)
+    field(:worth, :decimal)
 
-    field :transient_field, :integer
+    field(:transient_field, :integer)
 
-    has_many :groups, ExAudit.Test.UserGroup
+    has_many(:groups, ExAudit.Test.UserGroup)
 
     timestamps()
   end
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:email, :name])
+    |> cast(params, [:email, :name, :worth])
   end
 end

--- a/example/util.ex
+++ b/example/util.ex
@@ -1,8 +1,8 @@
 defmodule ExAudit.Test.Util do
   alias ExAudit.Test.{Repo, User}
 
-  def create_user(name \\ "Admin", email \\ "admin@example.com") do
-    params = %{name: name, email: email}
+  def create_user(name \\ "Admin", email \\ "admin@example.com", worth \\ Decimal.new("100")) do
+    params = %{name: name, email: email, worth: worth}
     changeset = User.changeset(%User{}, params)
     Repo.insert!(changeset)
   end

--- a/lib/diff/diff.ex
+++ b/lib/diff/diff.ex
@@ -31,8 +31,12 @@ defmodule ExAudit.Diff do
     :not_changed
   end
 
-  def diff(%Decimal{} = a, %Decimal{} = b) do
-    {:primitive_change, a, b}
+  def diff(a, b) when is_struct(a) and is_struct(b) do
+    if primitive_struct?(a) and primitive_struct?(b) do
+      {:primitive_change, a, b}
+    else
+      diff(Map.from_struct(a), Map.from_struct(b))
+    end
   end
 
   def diff(%{} = a, %{} = b) do
@@ -133,4 +137,12 @@ defmodule ExAudit.Diff do
     |> Enum.reverse()
     |> Enum.map(&reverse/1)
   end
+
+  defp primitive_struct?(map) when is_struct(map) do
+    primitive_structs = Application.get_env(:ex_audit, :primitive_structs, [])
+
+    map.__struct__ in primitive_structs
+  end
+
+  defp primitive_struct?(_), do: false
 end

--- a/lib/diff/diff.ex
+++ b/lib/diff/diff.ex
@@ -31,6 +31,10 @@ defmodule ExAudit.Diff do
     :not_changed
   end
 
+  def diff(%Decimal{} = a, %Decimal{} = b) do
+    {:primitive_change, a, b}
+  end
+
   def diff(%{} = a, %{} = b) do
     all_keys =
       (Map.keys(a) ++ Map.keys(b))

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule ExAudit.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:decimal, "~> 1.8.1"},
       {:ecto, "~> 3.4"},
       {:ecto_sql, "~> 3.4"},
       {:postgrex, "~> 0.15", only: :test},

--- a/priv/repo/migrations/20171018124842_initial_tables.exs
+++ b/priv/repo/migrations/20171018124842_initial_tables.exs
@@ -3,61 +3,67 @@ defmodule ExAudit.Test.Repo.Migrations.InitialTables do
 
   def change do
     create table(:users) do
-      add :name, :string
-      add :email, :string
+      add(:name, :string)
+      add(:email, :string)
+      add(:worth, :decimal)
 
       timestamps(type: :utc_datetime)
     end
 
     create table(:blog_post) do
-      add :title, :string
-      add :author_id, references(:users, on_update: :update_all, on_delete: :delete_all)
-      add :sections, :map
+      add(:title, :string)
+      add(:author_id, references(:users, on_update: :update_all, on_delete: :delete_all))
+      add(:sections, :map)
 
       timestamps(type: :utc_datetime)
     end
 
     create table(:tags) do
-      add :name, :string
+      add(:name, :string)
 
       timestamps(type: :utc_datetime)
     end
 
     create table(:posts_in_tags, primary_key: false) do
-      add :tag_id, references(:tags, on_update: :update_all, on_delete: :delete_all), primary_key: true
-      add :blog_post_id, references(:blog_post, on_update: :update_all, on_delete: :delete_all), primary_key: true
+      add(:tag_id, references(:tags, on_update: :update_all, on_delete: :delete_all),
+        primary_key: true
+      )
+
+      add(:blog_post_id, references(:blog_post, on_update: :update_all, on_delete: :delete_all),
+        primary_key: true
+      )
     end
 
     create table(:comments) do
-      add :author_id, references(:users, on_update: :update_all, on_delete: :delete_all)
-      add :body, :text
-      add :blog_post_id, references(:blog_post, on_update: :update_all, on_delete: :delete_all)
+      add(:author_id, references(:users, on_update: :update_all, on_delete: :delete_all))
+      add(:body, :text)
+      add(:blog_post_id, references(:blog_post, on_update: :update_all, on_delete: :delete_all))
 
       timestamps(type: :utc_datetime)
     end
 
     create table(:versions) do
       # The patch in Erlang External Term Format
-      add :patch, :binary
+      add(:patch, :binary)
 
       # supports UUID and other types as well
-      add :entity_id, :integer
+      add(:entity_id, :integer)
 
       # name of the table the entity is in
-      add :entity_schema, :string
+      add(:entity_schema, :string)
 
       # type of the action that has happened to the entity (created, updated, deleted)
-      add :action, :string
+      add(:action, :string)
 
       # when has this happened
-      add :recorded_at, :utc_datetime_usec
+      add(:recorded_at, :utc_datetime_usec)
 
       # was this change part of a rollback?
-      add :rollback, :boolean, default: false
+      add(:rollback, :boolean, default: false)
 
       # optional fields that you can define yourself
       # for example, it's a good idea to track who did the change
-      add :actor_id, references(:users, on_update: :update_all, on_delete: :nilify_all)
+      add(:actor_id, references(:users, on_update: :update_all, on_delete: :nilify_all))
     end
   end
 end

--- a/test/diff_test.exs
+++ b/test/diff_test.exs
@@ -74,4 +74,14 @@ defmodule DiffTest do
              baz: {:removed, 1}
            }
   end
+
+  test "Decimals are treated as primitives" do
+    val1 = Decimal.new("100")
+    val2 = Decimal.new("2000.00")
+
+    a = %{foo: val1}
+    b = %{foo: val2}
+
+    assert %{foo: {:changed, {:primitive_change, val1, val2}}} == Diff.diff(a, b)
+  end
 end


### PR DESCRIPTION
I ran into issues with ExAudit tracking only the parts of a Decimal that changed (https://github.com/ZennerIoT/ex_audit/issues/37) so I forked and made it treat Decimals as primitives. Then I figured that which structs one wants to consider as primitives might as well be configurable, so I added a new `: primitive_structs` config for that.

I figure the README should be updated with this information and maybe I should remove the Decimal dependency and make the tests use a custom struct instead. But I thought I'd get feedback first. Is this something you would be interesting in incorporating?