### PR TITLE
Add configurable struct primitives

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:ecto, :ecto_sql],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ config :ex_audit,
   ]
 ```
 
+Optionally, you can tell ExAudit to treat certain structs as primitives and not record internal changes for the 
+struct. Add these under the key `:primitive_structs` in your config. So for example, if you configured `Date` to be treated as a primitive:
+
+```elixir
+config :ex_audit,
+  ecto_repos: [ExAudit.Test.Repo],
+  version_schema: ExAudit.Test.Version,
+  tracked_schemas: [
+    ExAudit.Test.User,
+    ExAudit.Test.BlogPost,
+    ExAudit.Test.BlogPost.Section,
+    ExAudit.Test.Comment
+  ],
+  primitive_structs: [
+    Date
+  ]
+```
+
+then the patch would record the entire Date struct as a change:
+
+```elixir
+{:primitive_change, ~D[2000-01-01], ~D[2000-01-18]}
+```
+
+instead of descending into the struct to find the individual part that changed:
+
+```elixir
+{:changed, %{day: {:changed, {:primitive_change, 1, 18}}}}
+```
+
 ### Version Schema and Migration
 
 You need to copy the migration and the schema module for the versions table. This allows you to add custom fields

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,4 +19,7 @@ config :ex_audit,
     ExAudit.Test.BlogPost,
     ExAudit.Test.BlogPost.Section,
     ExAudit.Test.Comment
+  ],
+  primitive_structs: [
+    Date
   ]

--- a/example/user.ex
+++ b/example/user.ex
@@ -7,6 +7,7 @@ defmodule ExAudit.Test.User do
   schema "users" do
     field :email, :string
     field :name, :string
+    field :birthday, :date
 
     field :transient_field, :integer
 
@@ -17,6 +18,6 @@ defmodule ExAudit.Test.User do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:email, :name])
+    |> cast(params, [:email, :name, :birthday])
   end
 end

--- a/lib/diff/diff.ex
+++ b/lib/diff/diff.ex
@@ -31,6 +31,14 @@ defmodule ExAudit.Diff do
     :not_changed
   end
 
+  def diff(a, b) when is_struct(a) and is_struct(b) do
+    if primitive_struct?(a) and primitive_struct?(b) do
+      {:primitive_change, a, b}
+    else
+      diff(Map.from_struct(a), Map.from_struct(b))
+    end
+  end
+
   def diff(%{} = a, %{} = b) do
     all_keys =
       (Map.keys(a) ++ Map.keys(b))
@@ -129,4 +137,14 @@ defmodule ExAudit.Diff do
     |> Enum.reverse()
     |> Enum.map(&reverse/1)
   end
+
+  ## PRIVATE
+
+  defp primitive_struct?(map) when is_struct(map) do
+    primitive_structs = Application.get_env(:ex_audit, :primitive_structs, [])
+
+    map.__struct__ in primitive_structs
+  end
+
+  defp primitive_struct?(_), do: false
 end

--- a/lib/diff/diff.ex
+++ b/lib/diff/diff.ex
@@ -31,8 +31,8 @@ defmodule ExAudit.Diff do
     :not_changed
   end
 
-  def diff(a, b) when is_struct(a) and is_struct(b) do
-    if primitive_struct?(a) and primitive_struct?(b) do
+  def diff(%{__struct__: a_struct} = a, %{__struct__: b_struct} = b) do
+    if primitive_struct?(a_struct) and primitive_struct?(b_struct) do
       {:primitive_change, a, b}
     else
       diff(Map.from_struct(a), Map.from_struct(b))
@@ -140,11 +140,9 @@ defmodule ExAudit.Diff do
 
   ## PRIVATE
 
-  defp primitive_struct?(map) when is_struct(map) do
+  defp primitive_struct?(type) do
     primitive_structs = Application.get_env(:ex_audit, :primitive_structs, [])
 
-    map.__struct__ in primitive_structs
+    type in primitive_structs
   end
-
-  defp primitive_struct?(_), do: false
 end

--- a/priv/repo/migrations/20200519214139_add_birthday_to_user.exs
+++ b/priv/repo/migrations/20200519214139_add_birthday_to_user.exs
@@ -1,0 +1,9 @@
+defmodule ExAudit.Test.Repo.Migrations.AddBirthdayToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :birthday, :date
+    end
+  end
+end

--- a/test/diff_test.exs
+++ b/test/diff_test.exs
@@ -74,4 +74,14 @@ defmodule DiffTest do
              baz: {:removed, 1}
            }
   end
+
+  test "structs configured as primitives are treated as primitives" do
+    val1 = Date.new(2020, 1, 1)
+    val2 = Date.new(2020, 2, 2)
+
+    a = %{foo: val1}
+    b = %{foo: val2}
+
+    assert %{foo: {:changed, {:primitive_change, val1, val2}}} == Diff.diff(a, b)
+  end
 end


### PR DESCRIPTION
I ran into issues with ExAudit tracking only the parts of a Decimal that changed (#37) so I forked and made it treat Decimals as primitives. Then I figured that which structs one wants to consider as primitives might as well be configurable, so I added a new : primitive_structs config for that and made this branch not pull in Decimal as a dependency. I also added documentation to the README to explain how to use new config.

