### PR TITLE
Add default return on tracked schemas in repo.ex

### DIFF
--- a/lib/repo/repo.ex
+++ b/lib/repo/repo.ex
@@ -58,7 +58,7 @@ defmodule ExAudit.Repo do
       )
 
       defp tracked?(struct_or_changeset) do
-        tracked_schemas = Application.get_env(:ex_audit, :tracked_schemas)
+        tracked_schemas = Application.get_env(:ex_audit, :tracked_schemas, [])
 
         schema =
           case struct_or_changeset do


### PR DESCRIPTION
This is basically the same issue as #35. Repo.ex did not have a default value when looking in the env for tracked_schemas. 

Everything worked fine in development, but when we tried to deploy, apparently our deploy environment doesn't load the app env. So this line was returning nil instead of an empty list.The stack trace wasn't immediately obvious either. For future reference, here's what that looked like

```
(Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom...
(elixir 1.10.2) lib/enum.ex:1: Enumerable.impl_for!/1
(elixir 1.10.2) lib/enum.ex:166: Enumerable.member?/2
(elixir 1.10.2) lib/enum.ex:1682: Enum.member?/2
(exchange 0.1.0) lib/repo/repo.ex:72: Exchange.Repo.insert/2
(ecto_sql 3.4.2) lib/ecto/migrator.ex:640: Ecto.Migrator.verbose_schema_migration/3
(ecto_sql 3.4.2) lib/ecto/migrator.ex:293: Ecto.Migrator.async_migrate_maybe_in_transaction/6
(ecto_sql 3.4.2) lib/ecto/adapters/sql.ex:894: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
(db_connection 2.2.1) lib/db_connection.ex:1427: DBConnection.run_transaction/4
```