### PR TITLE
Add repo.latest function to only get most recent Version

### DIFF
--- a/lib/repo/queryable.ex
+++ b/lib/repo/queryable.ex
@@ -92,6 +92,9 @@ defmodule ExAudit.Queryable do
             where: v.entity_id == ^id,
             where: v.entity_schema == ^struct
           )
+
+        _ ->
+          raise ArgumentError, "Must pass an Ecto Schema struct with an id"
       end
 
     Ecto.Repo.Queryable.one(module, query, [])

--- a/lib/repo/queryable.ex
+++ b/lib/repo/queryable.ex
@@ -74,6 +74,29 @@ defmodule ExAudit.Queryable do
     end
   end
 
+  def latest(module, struct) do
+    import Ecto.Query
+
+    query =
+      from(
+        v in version_schema(),
+        order_by: [desc: :recorded_at],
+        limit: 1
+      )
+
+    query =
+      case struct do
+        %{__struct__: struct, id: id} when nil not in [struct, id] ->
+          from(
+            v in query,
+            where: v.entity_id == ^id,
+            where: v.entity_schema == ^struct
+          )
+      end
+
+    Ecto.Repo.Queryable.one(module, query, [])
+  end
+
   @drop_fields [:__meta__, :__struct__]
 
   def revert(module, version, opts) do

--- a/lib/repo/repo.ex
+++ b/lib/repo/repo.ex
@@ -186,6 +186,10 @@ defmodule ExAudit.Repo do
       def revert(version, opts \\ []) do
         ExAudit.Queryable.revert(__MODULE__, version, opts)
       end
+
+      def latest(struct) do
+        ExAudit.Queryable.latest(__MODULE__, struct)
+      end
     end
   end
 
@@ -201,6 +205,11 @@ defmodule ExAudit.Repo do
      `false` by default.
   """
   @callback history(struct, opts :: list) :: [version :: struct]
+
+  @doc """
+  Loads the most recent version record for the given struct.
+  """
+  @callback latest(struct) :: version :: struct
 
   @doc """
   Undoes the changes made in the given version, as well as all of the following versions.

--- a/test/ex_audit_test.exs
+++ b/test/ex_audit_test.exs
@@ -95,6 +95,12 @@ defmodule ExAuditTest do
            }
   end
 
+  test "latest handles invalid input" do
+    assert_raise ArgumentError, fn ->
+      Repo.latest(%User{})
+    end
+  end
+
   test "should track custom data" do
     user = Repo.insert!(User.changeset(%User{}, %{name: "Admin", email: "admin@example.com"}))
 

--- a/test/ex_audit_test.exs
+++ b/test/ex_audit_test.exs
@@ -70,6 +70,31 @@ defmodule ExAuditTest do
     assert length(versions) == 3
   end
 
+  test "can get latest revision" do
+    params = %{
+      name: "Ben Munat",
+      email: "foo@bar.com"
+    }
+
+    changeset = User.changeset(%User{}, params)
+
+    {:ok, user} = Repo.insert(changeset)
+
+    params = %{
+      email: "real@email.com"
+    }
+
+    changeset = User.changeset(user, params)
+
+    {:ok, user} = Repo.update(changeset)
+
+    assert %Version{} = latest = Repo.latest(user)
+
+    assert latest.patch == %{
+             email: {:changed, {:primitive_change, "foo@bar.com", "real@email.com"}}
+           }
+  end
+
   test "should track custom data" do
     user = Repo.insert!(User.changeset(%User{}, %{name: "Admin", email: "admin@example.com"}))
 


### PR DESCRIPTION
While integrating with ExAudit I found that I kept calling Repo.history and piping it into List.first or hd(). In fact the only place ever actually looked at more than the most recent was in a test. So I added the included Repo.lastest function to just get the latest Version record for the given Schema struct.