### PR TITLE
make tracked? overridable

### DIFF
--- a/lib/repo/repo.ex
+++ b/lib/repo/repo.ex
@@ -57,6 +57,23 @@ defmodule ExAudit.Repo do
         delete!: 2
       )
 
+      @doc """
+        Decides based on config `tracked_schema` wether the current schema is tracked or not.
+        Can be overwritten for custom tracking logic.
+
+        E.g.
+        ```
+          def tracked?(struct_or_schema) do
+            tracked? =
+              case Process.get(__MODULE__) do
+                %{tracked?: true} -> true
+                _ -> false
+              end
+
+            tracked? && super(struct_or_schema)
+          end
+        ```
+      """
       def tracked?(struct_or_changeset) do
         tracked_schemas = Application.get_env(:ex_audit, :tracked_schemas, [])
 

--- a/lib/repo/repo.ex
+++ b/lib/repo/repo.ex
@@ -57,7 +57,7 @@ defmodule ExAudit.Repo do
         delete!: 2
       )
 
-      defp tracked?(struct_or_changeset) do
+      def tracked?(struct_or_changeset) do
         tracked_schemas = Application.get_env(:ex_audit, :tracked_schemas, [])
 
         schema =
@@ -73,6 +73,8 @@ defmodule ExAudit.Repo do
       end
 
       @compile {:inline, tracked?: 1}
+
+      defoverridable(tracked?: 1)
 
       def insert(struct, opts) do
         if tracked?(struct) do


### PR DESCRIPTION
Hey there,
I am looking for a possibility to have more control over tracking.
This was the simplest approach I could think of to make it work.

I got a plug that I call where I want to track and simply add a `enabled?: true` to the current process directory. 
Then i override the `tracked?` function to look for that key.

Any thoughts on this?