### PR TITLE
add notification function on update

### DIFF
--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -78,6 +78,11 @@ defmodule ExAudit.Tracking do
 
       _ ->
         opts = Keyword.drop(opts, [:on_conflict, :conflict_target])
+        notification_module = Application.get_env(:ex_audit, :notification_module)
+        notification_function = Application.get_env(:ex_audit, :notification_function)
+        if Kernel.function_exported?(notification_module, notification_function, 1) do
+          apply(notification_module, notification_function, changes)
+        end
         module.insert_all(version_schema(), changes, opts)
     end
   end


### PR DESCRIPTION
Hello :) 

My need was to send a notification slack on an entity update. An easy way to solve this problem is to add a callback mechanism that triggers the desired function when a change occurs, and then use some pattern matching on the change struct to act upon updates on a particular schema and field.
`notification_module` and `notification_method` are defined in the config file of the main application and they represent the name of the function and the name of the module in which it is implemented.

A notification handler with arity=1 can be optionally configured to receive notifications whenever a change needs to be tracked elsewhere eg. a Slack channel.
 
Any thoughts?