### PR TITLE
Support for :second when recorded_at is :utc_datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ config :ex_audit,
   ]
 ```
 
-Optionally, you can tell ExAudit to treat certain structs as primitives and not record internal changes for the 
+Optionally, you can tell ExAudit to treat certain structs as primitives and not record internal changes for the
 struct. Add these under the key `:primitive_structs` in your config. So for example, if you configured `Date` to be treated as a primitive:
 
 ```elixir
@@ -139,7 +139,7 @@ defmodule MyApp.Version do
     field :action, ExAudit.Type.Action
 
     # when has this happened
-    field :recorded_at, :utc_datetime
+    field :recorded_at, :utc_datetime_usec
 
     # was this change part of a rollback?
     field :rollback, :boolean, default: false

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ instead of descending into the struct to find the individual part that changed:
 {:changed, %{day: {:changed, {:primitive_change, 1, 18}}}}
 ```
 
+### Precision in the timestamp
+
+When you are generating the tables of *ex_audit*, in some cases, the precision in the fields are in `:millisecond`, in such case you can change the precision of the field.
+
+```elixir
+config :ex_audit,
+  # ...
+  precision: :millisecond, # :microsecond is default
+  # ...
+```
+
 ### Version Schema and Migration
 
 You need to copy the migration and the schema module for the versions table. This allows you to add custom fields

--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -60,7 +60,7 @@ defmodule ExAudit.Tracking do
   end
 
   def insert_versions(module, changes, opts) do
-    now = DateTime.utc_now()
+    now = DateTime.utc_now() |> with_precision()
 
     custom_fields =
       Keyword.get(opts, :ex_audit_custom, [])
@@ -109,6 +109,13 @@ defmodule ExAudit.Tracking do
     deleted_structs = find_assoc_deletion(module, struct, opts)
 
     insert_versions(module, deleted_structs, opts)
+  end
+
+  defp with_precision(date) do
+    case precision = Application.get_env(:ex_audit, :precision) do
+      nil -> date
+      precision -> DateTime.truncate(date, precision)
+    end
   end
 
   defp tracked_schemas do

--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -112,7 +112,7 @@ defmodule ExAudit.Tracking do
   end
 
   defp with_precision(date) do
-    case precision = Application.get_env(:ex_audit, :precision) do
+    case Application.get_env(:ex_audit, :precision) do
       nil -> date
       precision -> DateTime.truncate(date, precision)
     end

--- a/test/precision_test.exs
+++ b/test/precision_test.exs
@@ -1,5 +1,6 @@
 defmodule PrecisionTest do
-  use ExUnit.Case
+  use ExUnit.Case,
+    async: false
 
   import Ecto.Query
 

--- a/test/precision_test.exs
+++ b/test/precision_test.exs
@@ -1,0 +1,31 @@
+defmodule PrecisionTest do
+  use ExUnit.Case
+
+  import Ecto.Query
+
+  alias ExAudit.Test.{Repo, User, Version, Util}
+
+  setup_all do
+    current = Application.get_env(:ex_audit, :precision)
+
+    Application.put_env(:ex_audit, :precision, :microsecond)
+
+    on_exit(fn -> Application.put_env(:ex_audit, :precision, current) end)
+  end
+
+  test "adjust the precision to `second` in the field `recorded_at`" do
+    user = Util.create_user("Juan Zuñiga")
+
+    changeset = User.changeset(user, %{name: "@neodevelop"})
+
+    assert {:ok, user} = Repo.update(changeset)
+
+    query =
+      from(v in Version,
+        where: v.entity_id == ^user.id,
+        where: v.entity_schema == ^User
+      )
+
+    assert 2 = Repo.aggregate(query, :count, :id)
+  end
+end


### PR DESCRIPTION
I've already update the README, I also think it's the solution, but in any case.