### PR TITLE
Add typespecs for Ecto types

### DIFF
--- a/lib/repo/action_type.ex
+++ b/lib/repo/action_type.ex
@@ -1,7 +1,7 @@
 defmodule ExAudit.Type.Action do
   use Ecto.Type
 
-  @type t() :: atom()
+  @type t() :: :created | :updated | :deleted
 
   @actions ~w[created updated deleted]a
 

--- a/lib/repo/action_type.ex
+++ b/lib/repo/action_type.ex
@@ -1,6 +1,8 @@
 defmodule ExAudit.Type.Action do
   use Ecto.Type
 
+  @type t() :: atom()
+
   @actions ~w[created updated deleted]a
 
   for action <- @actions do

--- a/lib/repo/patch_type.ex
+++ b/lib/repo/patch_type.ex
@@ -1,6 +1,8 @@
 defmodule ExAudit.Type.Patch do
   use Ecto.Type
 
+  @type t() :: map()
+
   def cast(a), do: {:ok, a}
   def dump(patch), do: {:ok, :erlang.term_to_binary(patch)}
   def load(binary), do: {:ok, :erlang.binary_to_term(binary)}

--- a/lib/repo/patch_type.ex
+++ b/lib/repo/patch_type.ex
@@ -1,7 +1,7 @@
 defmodule ExAudit.Type.Patch do
   use Ecto.Type
 
-  @type t() :: map()
+  @type t() :: ExAudit.Diff.changes()
 
   def cast(a), do: {:ok, a}
   def dump(patch), do: {:ok, :erlang.term_to_binary(patch)}

--- a/lib/repo/schema_type.ex
+++ b/lib/repo/schema_type.ex
@@ -1,6 +1,8 @@
 defmodule ExAudit.Type.Schema do
   use Ecto.Type
 
+  @type t() :: module()
+
   def cast(schema) when is_atom(schema) do
     case Enum.member?(schemas(), schema) do
       true -> {:ok, schema}


### PR DESCRIPTION
This allows users to define complete typespecs for their Version modules, without dialyzer (correctly) complaining about
```
:0:unknown_type
Unknown type: ExAudit.Type.Action.t/0.

:0:unknown_type
Unknown type: ExAudit.Type.Patch.t/0.

:0:unknown_type
Unknown type: ExAudit.Type.Schema.t/0.
```