### PR TITLE
call version changeset

### DIFF
--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -61,6 +61,7 @@ defmodule ExAudit.Tracking do
 
   def insert_versions(module, changes, opts) do
     now = DateTime.utc_now()
+    empty_version_schema = struct(version_schema(), %{})
 
     custom_fields =
       Keyword.get(opts, :ex_audit_custom, [])
@@ -68,8 +69,14 @@ defmodule ExAudit.Tracking do
 
     changes =
       Enum.map(changes, fn change ->
-        change = Map.put(change, :recorded_at, now)
-        Map.merge(change, custom_fields)
+        change =
+          change
+          |> Map.put(:recorded_at, now)
+          |> Map.merge(custom_fields)
+
+        version_schema()
+        |> apply(:changeset, [empty_version_schema, change])
+        |> Map.get(:changes)
       end)
 
     case changes do


### PR DESCRIPTION
Currently even tho documentation provides that &changeset/2 must be provided in Version schema, it isnt actually called.

This calls changeset.

It enables custom version data mapping before insert. In many cases examples in readme are fine, but with more complex audit metadata it requires all data mapping be done in each place where something is updated/inserted/so on. It is both repetative and error prone. This fix gives one central place where version it self can change and prepare params before actual insert.

```
user = %User{id: 5}
MyApp.Repo.insert(entity, ex_audit_custom: [user: user])

defmodule Version do
  ...elixir
  def changeset(struct, params \\ %{}) do
    custom_params = %{user_id: get_in(params, [:user, :id])}

    struct
    |> cast(params, [:patch, :entity_id, :entity_schema, :action, :recorded_at, :rollback])
    |> cast(custom_params, [:user_id]) # custom fields
  end
end
```