### PR TITLE
allow custom history fetching

### DIFF
--- a/example/repo.ex
+++ b/example/repo.ex
@@ -4,4 +4,12 @@ defmodule ExAudit.Test.Repo do
     adapter: Ecto.Adapters.Postgres
 
   use ExAudit.Repo
+
+  def custom_history_fetch_latest_version_only(struct, opts \\ []) do
+    ExAudit.Queryable.history(__MODULE__, struct, fn module, query, opts ->
+      import Ecto.Query
+
+      Ecto.Repo.Queryable.one(module, limit(query, 1), opts)
+    end, opts)
+  end
 end

--- a/lib/repo/queryable.ex
+++ b/lib/repo/queryable.ex
@@ -15,7 +15,7 @@ defmodule ExAudit.Queryable do
     Ecto.Repo.Queryable.delete_all(module, queryable, opts)
   end
 
-  def history(module, struct, opts) do
+  def history(module, struct, query_callback, opts) do
     import Ecto.Query
 
     query =
@@ -40,7 +40,7 @@ defmodule ExAudit.Queryable do
           )
       end
 
-    versions = Ecto.Repo.Queryable.all(module, query, opts)
+    versions = query_callback.(module, query, opts)
 
     if Keyword.get(opts, :render_struct, false) do
       {versions, oldest_struct} =

--- a/lib/repo/repo.ex
+++ b/lib/repo/repo.ex
@@ -206,7 +206,7 @@ defmodule ExAudit.Repo do
       # additional functions
 
       def history(struct, opts \\ []) do
-        ExAudit.Queryable.history(__MODULE__, struct, opts)
+        ExAudit.Queryable.history(__MODULE__, struct, &Ecto.Repo.Queryable.all/3, opts)
       end
 
       def revert(version, opts \\ []) do

--- a/test/assoc_test.exs
+++ b/test/assoc_test.exs
@@ -49,6 +49,26 @@ defmodule AssocTest do
            } = version
   end
 
+  test "can manipulte history fetching" do
+    {:ok, old_date} = Date.new(2000, 1, 1)
+    params = %{name: "Bob", email: "foo@bar.com", birthday: old_date}
+    changeset = User.changeset(%User{}, params)
+    {:ok, user} = Repo.insert(changeset)
+
+    new_date = Date.add(old_date, 17)
+    params = %{birthday: new_date}
+    changeset = User.changeset(user, params)
+    {:ok, user} = Repo.update(changeset)
+
+    version = Repo.custom_history_fetch_latest_version_only(user)
+
+    assert %{
+             patch: %{
+               birthday: {:changed, {:primitive_change, ^old_date, ^new_date}}
+             }
+           } = version
+  end
+
   test "should track cascading deletions (before they happen)" do
     user = Util.create_user()
 


### PR DESCRIPTION
Concrete use-case: pagination. There might be other use cases as well.

For more feature proof solution part after querying also should be extracted to separate function that can be overwritten. Its outside of scope for my current task.