### PR TITLE
Refactor CustomData to use ETS table directly on get

### DIFF
--- a/lib/tracking/custom_data.ex
+++ b/lib/tracking/custom_data.ex
@@ -10,7 +10,7 @@ defmodule ExAudit.CustomData do
   end
 
   def init(nil) do
-    ets = :ets.new(:track_by_pid, [:public])
+    ets = :ets.new(__MODULE__, [:protected, :named_table])
     {:ok, ets}
   end
 
@@ -24,23 +24,9 @@ defmodule ExAudit.CustomData do
     {:reply, :ok, ets}
   end
 
-  def handle_call({:get, pid}, _, ets) do
-    case :ets.lookup(ets, pid) do
-      [] ->
-        {:reply, [], ets}
-
-      list ->
-        values = Enum.flat_map(list, &elem(&1, 1))
-        {:reply, values, ets}
-    end
-  end
-
-  def get() do
-    GenServer.call(__MODULE__, {:get, self()})
-  end
-
-  def get(pid) do
-    GenServer.call(__MODULE__, {:get, pid})
+  def get(pid \\ self()) do
+    :ets.lookup(__MODULE__, pid)
+    |> Enum.flat_map(&elem(&1, 1))
   end
 
   def handle_info({:DOWN, _, :process, pid, _}, ets) do


### PR DESCRIPTION
Hey team while doing some benchmarking I noticed that CustomData can become a bottleneck when fetching custom data to be stored as part of ExAudit tracking

Having a named ETS table makes it easy to directly fetch data without going through the table owner.

We could also do the same for "track" but it's a bit more complicated. We could move the table back to be `public` and change it so that when `track` is called `:ets.insert` is called. 

The missing piece is the `Process.monitor` part that could be fired as a `GenServer.cast` after inserting which would at least not block the client waiting for a response. Happy to do it if we think that's a good approach