### PR TITLE
Use bigint type for entity_id in the create_version_table.exs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ defmodule MyApp.Migrations.AddVersions do
       add :patch, :binary
 
       # supports UUID and other types as well
-      add :entity_id, :integer
+      add :entity_id, :bigint
 
       # name of the table the entity is in
       add :entity_schema, :string


### PR DESCRIPTION
Since the `id` column created by default by Ecto is not an `integer` but a `bigint`, it should be the same way in the example to prevent confusion and problems.

The `field` definition in the schema itself should still be `integer`, only the migration type is changed.