### PR TITLE
Prefixed table support

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,6 +16,7 @@ config :ex_audit,
   version_schema: ExAudit.Test.Version,
   tracked_schemas: [
     ExAudit.Test.User,
+    ExAudit.Test.PrivateUser,
     ExAudit.Test.BlogPost,
     ExAudit.Test.BlogPost.Section,
     ExAudit.Test.Comment

--- a/example/private_user.ex
+++ b/example/private_user.ex
@@ -1,0 +1,20 @@
+defmodule ExAudit.Test.PrivateUser do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @derive {ExAudit.Tracker, except: [:transient_field]}
+
+  @schema_prefix "private"
+  schema "users" do
+    field :email, :string
+    field :name, :string
+    field :birthday, :date
+
+    timestamps()
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:email, :name, :birthday])
+  end
+end

--- a/lib/repo/schema_type.ex
+++ b/lib/repo/schema_type.ex
@@ -25,7 +25,7 @@ defmodule ExAudit.Type.Schema do
 
   def dump(schema) do
     case Enum.member?(schemas(), schema) do
-      true -> {:ok, schema.__schema__(:source)}
+      true -> {:ok, schema_name(schema)}
       _ -> :error
     end
   end
@@ -33,8 +33,16 @@ defmodule ExAudit.Type.Schema do
   defp get_schema_by_table(table) do
     schemas()
     |> Enum.find(fn schema ->
-      schema.__schema__(:source) == table
+      schema_name(schema) == table
     end)
+  end
+
+  defp schema_name(schema) do
+    if prefix = schema.__schema__(:prefix) do
+      prefix <> "." <> schema.__schema__(:source)
+    else
+      schema.__schema__(:source)
+    end
   end
 
   def type, do: :string

--- a/priv/repo/migrations/20171018124842_initial_tables.exs
+++ b/priv/repo/migrations/20171018124842_initial_tables.exs
@@ -9,6 +9,15 @@ defmodule ExAudit.Test.Repo.Migrations.InitialTables do
       timestamps(type: :utc_datetime)
     end
 
+    execute("CREATE SCHEMA private")
+
+    create table(:users, prefix: "private") do
+      add :name, :string
+      add :email, :string
+
+      timestamps(type: :utc_datetime)
+    end
+
     create table(:blog_post) do
       add :title, :string
       add :author_id, references(:users, on_update: :update_all, on_delete: :delete_all)

--- a/test/schema_type_test.exs
+++ b/test/schema_type_test.exs
@@ -1,0 +1,26 @@
+defmodule SchemaTypeTest do
+  use ExUnit.Case
+
+  alias ExAudit.Type.Schema, as: SchemaType
+  alias ExAudit.Test.{User, PrivateUser}
+
+  describe "load/1" do
+    test "should load unprefixed schema" do
+      assert SchemaType.load("users") == {:ok, User}
+    end
+
+    test "should load prefixed schema" do
+      assert SchemaType.load("private.users") == {:ok, PrivateUser}
+    end
+  end
+
+  describe "dump/1" do
+    test "should dump unprefixed schema" do
+      assert SchemaType.dump(User) == {:ok, "users"}
+    end
+
+    test "should dump prefixed schema" do
+      assert SchemaType.dump(PrivateUser) == {:ok, "private.users"}
+    end
+  end
+end


### PR DESCRIPTION
Support schema prefixes in `ExAudit.Type.Schema`. If a schema defines a `@schema_prefix`, prepend the dumped value like so: `prefix.table`. If no prefix is set, don't prepend the table name. This helps avoid potential name conflicts when dealing with postgres tables with the same name but different schemas.